### PR TITLE
ci(security): add targeted Semgrep CE gate

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,28 @@
+name: Semgrep CE
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Targeted rules
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install pinned Semgrep CE
+        run: |
+          python3 -m venv "$RUNNER_TEMP/semgrep"
+          "$RUNNER_TEMP/semgrep/bin/pip" install --disable-pip-version-check semgrep==1.136.0 setuptools==75.8.0
+          echo "$RUNNER_TEMP/semgrep/bin" >> "$GITHUB_PATH"
+      - name: Prove local rules detect their regression fixtures
+        run: ci/semgrep/validate-rules.sh
+      - name: Enforce targeted rules
+        run: semgrep scan --config .semgrep.yml --error --metrics=off --disable-version-check --exclude ci/semgrep/fixtures

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Prove local rules detect their regression fixtures
         run: ci/semgrep/validate-rules.sh
       - name: Enforce targeted rules
-        run: semgrep scan --strict --config .semgrep.yml --error --metrics=off --disable-version-check --exclude ci/semgrep/fixtures --exclude apps/web/src/app/competition/reports/2025/week-3/page.tsx
+        run: semgrep scan --strict --config .semgrep.yml --error --metrics=off --disable-version-check --exclude ci/semgrep/fixtures

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,17 +12,14 @@ jobs:
     name: Targeted rules
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    container:
+      image: semgrep/semgrep:1.136.0@sha256:cda1b566fafbf6010a02a3ea1d265b1c8eba4380e489a13891a102243d81ca6f
     steps:
       - name: Check out source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - name: Install pinned Semgrep CE
-        run: |
-          python3 -m venv "$RUNNER_TEMP/semgrep"
-          "$RUNNER_TEMP/semgrep/bin/pip" install --disable-pip-version-check semgrep==1.136.0 setuptools==75.8.0
-          echo "$RUNNER_TEMP/semgrep/bin" >> "$GITHUB_PATH"
       - name: Prove local rules detect their regression fixtures
         run: ci/semgrep/validate-rules.sh
       - name: Enforce targeted rules
-        run: semgrep scan --config .semgrep.yml --error --metrics=off --disable-version-check --exclude ci/semgrep/fixtures
+        run: semgrep scan --strict --config .semgrep.yml --error --metrics=off --disable-version-check --exclude ci/semgrep/fixtures --exclude apps/web/src/app/competition/reports/2025/week-3/page.tsx

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,18 +1,4 @@
 rules:
-  - id: gauntlet.no-sensitive-http-logging
-    message: Never log request bodies or authorization headers.
-    severity: ERROR
-    languages: [typescript, javascript]
-    patterns:
-      - pattern-either:
-          - pattern: $LOGGER.$METHOD(..., $REQ.body, ...)
-          - pattern: $LOGGER.$METHOD(..., $REQ.headers.authorization, ...)
-          - pattern: $LOGGER.$METHOD(..., $REQ.headers["authorization"], ...)
-      - metavariable-regex:
-          metavariable: $METHOD
-          regex: ^(log|info|debug|warn|error)$
-      - pattern-not: $LOGGER.$METHOD(..., email.body, ...)
-
   - id: gauntlet.no-direct-cron-secret-comparison
     message: Use the fail-closed cron authorization helper; direct env interpolation can accept Bearer undefined.
     severity: ERROR
@@ -91,9 +77,13 @@ rules:
     severity: ERROR
     languages: [typescript, javascript]
     patterns:
-      - pattern-inside: |
-          const $SECRET = process.env.CRON_SECRET;
-          ...
+      - pattern-either:
+          - pattern-inside: |
+              const $SECRET = process.env.CRON_SECRET;
+              ...
+          - pattern-inside: |
+              let $SECRET = process.env.CRON_SECRET;
+              ...
       - pattern-either:
           - pattern: '$REQUEST.headers.get("authorization") === `Bearer ${$SECRET}`'
           - pattern: '$REQUEST.headers.get("authorization") !== `Bearer ${$SECRET}`'
@@ -113,3 +103,5 @@ rules:
       - pattern-either:
           - pattern: '$REQUEST.headers.get("authorization") === $EXPECTED'
           - pattern: '$REQUEST.headers.get("authorization") !== $EXPECTED'
+          - pattern: '$EXPECTED === $REQUEST.headers.get("authorization")'
+          - pattern: '$EXPECTED !== $REQUEST.headers.get("authorization")'

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -7,6 +7,14 @@ rules:
       - pattern: '$REQUEST.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`'
       - pattern: '$REQUEST.headers.get("authorization") !== `Bearer ${process.env.CRON_SECRET}`'
 
+  - id: gauntlet.no-bracket-cron-secret-comparison
+    message: Use the fail-closed cron authorization helper; bracketed env access can accept Bearer undefined.
+    severity: ERROR
+    languages: [typescript, javascript]
+    pattern-either:
+      - pattern: '$REQUEST.headers.get("authorization") === `Bearer ${process.env["CRON_SECRET"]}`'
+      - pattern: '$REQUEST.headers.get("authorization") !== `Bearer ${process.env["CRON_SECRET"]}`'
+
   - id: gauntlet.require-gemini-output-bound
     message: Gemini clients must set maxOutputTokens to bound cost and response size.
     severity: ERROR
@@ -50,6 +58,21 @@ rules:
           metavariable: $DEFAULT
           regex: .+
 
+  - id: gauntlet.no-bracket-secret-default
+    message: Bracketed cron and AI secrets must fail closed instead of using a hard-coded fallback.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-either:
+          - pattern: process.env[$NAME] || "$DEFAULT"
+          - pattern: process.env[$NAME] ?? "$DEFAULT"
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: ^["'](?i:.*(cron_secret|api_key|access_token|private_key).*)["']$
+      - metavariable-regex:
+          metavariable: $DEFAULT
+          regex: .+
+
   - id: gauntlet.no-secret-default-through-env-alias
     message: Aliasing process.env must not bypass fail-closed secret configuration.
     severity: ERROR
@@ -65,6 +88,32 @@ rules:
       - pattern-either:
           - pattern: $ENV.$NAME || "$DEFAULT"
           - pattern: $ENV.$NAME ?? "$DEFAULT"
+          - pattern: $ENV[$NAME] || "$DEFAULT"
+          - pattern: $ENV[$NAME] ?? "$DEFAULT"
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: (?i).*(cron_secret|api_key|access_token|private_key).*
+      - metavariable-regex:
+          metavariable: $DEFAULT
+          regex: .+
+
+  - id: gauntlet.no-secret-default-through-global-env-alias
+    message: Aliasing globalThis.process.env must not bypass fail-closed secret configuration.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              const $ENV = globalThis.process.env;
+              ...
+          - pattern-inside: |
+              let $ENV = globalThis.process.env;
+              ...
+      - pattern-either:
+          - pattern: $ENV.$NAME || "$DEFAULT"
+          - pattern: $ENV.$NAME ?? "$DEFAULT"
+          - pattern: $ENV[$NAME] || "$DEFAULT"
+          - pattern: $ENV[$NAME] ?? "$DEFAULT"
       - metavariable-regex:
           metavariable: $NAME
           regex: (?i).*(cron_secret|api_key|access_token|private_key).*

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -11,9 +11,7 @@ rules:
       - metavariable-regex:
           metavariable: $METHOD
           regex: ^(log|info|debug|warn|error)$
-      - metavariable-regex:
-          metavariable: $REQ
-          regex: ^(req|request)$
+      - pattern-not: $LOGGER.$METHOD(..., email.body, ...)
 
   - id: gauntlet.no-direct-cron-secret-comparison
     message: Use the fail-closed cron authorization helper; direct env interpolation can accept Bearer undefined.
@@ -31,6 +29,26 @@ rules:
       - pattern: 'new ChatGoogleGenerativeAI({ ... })'
       - pattern-not: 'new ChatGoogleGenerativeAI({ ..., maxOutputTokens: $LIMIT, ... })'
 
+  - id: gauntlet.require-gemini-output-bound-variable
+    message: Gemini options passed through a variable must set maxOutputTokens.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern: new ChatGoogleGenerativeAI($OPTIONS)
+      - pattern-either:
+          - pattern-inside: |
+              const $OPTIONS = { ... };
+              ...
+          - pattern-inside: |
+              let $OPTIONS = { ... };
+              ...
+      - pattern-not-inside: |
+          const $OPTIONS = { ..., maxOutputTokens: $LIMIT, ... };
+          ...
+      - pattern-not-inside: |
+          let $OPTIONS = { ..., maxOutputTokens: $LIMIT, ... };
+          ...
+
   - id: gauntlet.no-secret-default
     message: Cron and AI secrets must fail closed instead of using a hard-coded fallback.
     severity: ERROR
@@ -45,3 +63,53 @@ rules:
       - metavariable-regex:
           metavariable: $DEFAULT
           regex: .+
+
+  - id: gauntlet.no-secret-default-through-env-alias
+    message: Aliasing process.env must not bypass fail-closed secret configuration.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              const $ENV = process.env;
+              ...
+          - pattern-inside: |
+              let $ENV = process.env;
+              ...
+      - pattern-either:
+          - pattern: $ENV.$NAME || "$DEFAULT"
+          - pattern: $ENV.$NAME ?? "$DEFAULT"
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: (?i).*(cron_secret|api_key|access_token|private_key).*
+      - metavariable-regex:
+          metavariable: $DEFAULT
+          regex: .+
+
+  - id: gauntlet.no-indirect-cron-secret-comparison
+    message: Use the fail-closed cron authorization helper; aliasing the secret must not bypass review.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-inside: |
+          const $SECRET = process.env.CRON_SECRET;
+          ...
+      - pattern-either:
+          - pattern: '$REQUEST.headers.get("authorization") === `Bearer ${$SECRET}`'
+          - pattern: '$REQUEST.headers.get("authorization") !== `Bearer ${$SECRET}`'
+
+  - id: gauntlet.no-expected-header-cron-secret-comparison
+    message: Use the fail-closed cron authorization helper; a stored expected header must not bypass review.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              const $EXPECTED = `Bearer ${process.env.CRON_SECRET}`;
+              ...
+          - pattern-inside: |
+              let $EXPECTED = `Bearer ${process.env.CRON_SECRET}`;
+              ...
+      - pattern-either:
+          - pattern: '$REQUEST.headers.get("authorization") === $EXPECTED'
+          - pattern: '$REQUEST.headers.get("authorization") !== $EXPECTED'

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,47 @@
+rules:
+  - id: gauntlet.no-sensitive-http-logging
+    message: Never log request bodies or authorization headers.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-either:
+          - pattern: $LOGGER.$METHOD(..., $REQ.body, ...)
+          - pattern: $LOGGER.$METHOD(..., $REQ.headers.authorization, ...)
+          - pattern: $LOGGER.$METHOD(..., $REQ.headers["authorization"], ...)
+      - metavariable-regex:
+          metavariable: $METHOD
+          regex: ^(log|info|debug|warn|error)$
+      - metavariable-regex:
+          metavariable: $REQ
+          regex: ^(req|request)$
+
+  - id: gauntlet.no-direct-cron-secret-comparison
+    message: Use the fail-closed cron authorization helper; direct env interpolation can accept Bearer undefined.
+    severity: ERROR
+    languages: [typescript, javascript]
+    pattern-either:
+      - pattern: '$REQUEST.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`'
+      - pattern: '$REQUEST.headers.get("authorization") !== `Bearer ${process.env.CRON_SECRET}`'
+
+  - id: gauntlet.require-gemini-output-bound
+    message: Gemini clients must set maxOutputTokens to bound cost and response size.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern: 'new ChatGoogleGenerativeAI({ ... })'
+      - pattern-not: 'new ChatGoogleGenerativeAI({ ..., maxOutputTokens: $LIMIT, ... })'
+
+  - id: gauntlet.no-secret-default
+    message: Cron and AI secrets must fail closed instead of using a hard-coded fallback.
+    severity: ERROR
+    languages: [typescript, javascript]
+    patterns:
+      - pattern-either:
+          - pattern: process.env.$NAME || "$DEFAULT"
+          - pattern: process.env.$NAME ?? "$DEFAULT"
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: (?i).*(cron_secret|api_key|access_token|private_key).*
+      - metavariable-regex:
+          metavariable: $DEFAULT
+          regex: .+

--- a/apps/web/src/app/competition/reports/2025/week-3/page.tsx
+++ b/apps/web/src/app/competition/reports/2025/week-3/page.tsx
@@ -289,7 +289,7 @@ export default function Week3Report2025() {
       </div>
 
       {/* Data-driven Matchup Details */}
-      <h2 className="text-lg font-semibold">Matchup Details & Box Scores</h2>
+      <h2 className="text-lg font-semibold">Matchup Details &amp; Box Scores</h2>
       {data?.ok && data.data ? (
         <div className="space-y-8">
           {(data.data.leagues || []).map(l => (

--- a/ci/semgrep/README.md
+++ b/ci/semgrep/README.md
@@ -11,15 +11,17 @@ those fixtures. The invalid configuration fixture also proves unknown rule
 fields fail closed. Broad registry rules are not blocking until their findings have
 owners and their false-positive policy has been reviewed.
 
-The Week 3 report page is excluded because Semgrep 1.136 cannot parse its valid
-JSX text containing a raw ampersand. The exception is exact and can be removed
-when the pinned parser handles that syntax.
+These custom rules are narrow defense-in-depth checks. Native invariant tests
+and repository lint remain authoritative for privacy and application behavior;
+this policy does not claim generic sensitive-logging coverage.
+
+The Week 3 report uses the render-equivalent `&amp;` JSX entity so the pinned
+Semgrep parser can scan the complete product file without an exclusion.
 
 To run locally with Semgrep 1.136.0 on `PATH`:
 
 ```bash
 ci/semgrep/validate-rules.sh
 semgrep scan --strict --config .semgrep.yml --error --metrics=off \
-  --disable-version-check --exclude ci/semgrep/fixtures \
-  --exclude apps/web/src/app/competition/reports/2025/week-3/page.tsx
+  --disable-version-check --exclude ci/semgrep/fixtures
 ```

--- a/ci/semgrep/README.md
+++ b/ci/semgrep/README.md
@@ -1,15 +1,15 @@
 # Semgrep CE policy
 
 The pull-request workflow runs Semgrep Community Edition from a versioned,
-digest-pinned container on the GitHub runner. It uses no Semgrep account, token, cloud rules, source upload,
-SARIF, or GitHub Advanced Security permission.
+digest-pinned container on the GitHub runner. It uses no Semgrep account, token,
+cloud rules, source upload, SARIF, or GitHub Advanced Security permission.
 
 Only the reviewed rules vendored in `.semgrep.yml` block pull requests. Keep
 them narrow and high-confidence. Every rule must have an unsafe fixture in this
-directory and remain covered by `validate-rules.sh`; the production scan excludes
-those fixtures. The invalid configuration fixture also proves unknown rule
-fields fail closed. Broad registry rules are not blocking until their findings have
-owners and their false-positive policy has been reviewed.
+directory and remain covered by `validate-rules.sh`; the production scan
+excludes those fixtures. The invalid configuration fixture also proves unknown
+rule fields fail closed. Broad registry rules are not blocking until their
+findings have owners and their false-positive policy has been reviewed.
 
 These custom rules are narrow defense-in-depth checks. Native invariant tests
 and repository lint remain authoritative for privacy and application behavior;

--- a/ci/semgrep/README.md
+++ b/ci/semgrep/README.md
@@ -1,0 +1,19 @@
+# Semgrep CE policy
+
+The pull-request workflow runs pinned Semgrep Community Edition locally on the
+GitHub runner. It uses no Semgrep account, token, cloud rules, source upload,
+SARIF, or GitHub Advanced Security permission.
+
+Only the reviewed rules vendored in `.semgrep.yml` block pull requests. Keep
+them narrow and high-confidence. Every rule must have an unsafe fixture in this
+directory and remain covered by `validate-rules.sh`; the production scan excludes
+those fixtures. Broad registry rules are not blocking until their findings have
+owners and their false-positive policy has been reviewed.
+
+To run locally with Semgrep 1.136.0 on `PATH`:
+
+```bash
+ci/semgrep/validate-rules.sh
+semgrep scan --config .semgrep.yml --error --metrics=off \
+  --disable-version-check --exclude ci/semgrep/fixtures
+```

--- a/ci/semgrep/README.md
+++ b/ci/semgrep/README.md
@@ -1,19 +1,25 @@
 # Semgrep CE policy
 
-The pull-request workflow runs pinned Semgrep Community Edition locally on the
-GitHub runner. It uses no Semgrep account, token, cloud rules, source upload,
+The pull-request workflow runs Semgrep Community Edition from a versioned,
+digest-pinned container on the GitHub runner. It uses no Semgrep account, token, cloud rules, source upload,
 SARIF, or GitHub Advanced Security permission.
 
 Only the reviewed rules vendored in `.semgrep.yml` block pull requests. Keep
 them narrow and high-confidence. Every rule must have an unsafe fixture in this
 directory and remain covered by `validate-rules.sh`; the production scan excludes
-those fixtures. Broad registry rules are not blocking until their findings have
+those fixtures. The invalid configuration fixture also proves unknown rule
+fields fail closed. Broad registry rules are not blocking until their findings have
 owners and their false-positive policy has been reviewed.
+
+The Week 3 report page is excluded because Semgrep 1.136 cannot parse its valid
+JSX text containing a raw ampersand. The exception is exact and can be removed
+when the pinned parser handles that syntax.
 
 To run locally with Semgrep 1.136.0 on `PATH`:
 
 ```bash
 ci/semgrep/validate-rules.sh
-semgrep scan --config .semgrep.yml --error --metrics=off \
-  --disable-version-check --exclude ci/semgrep/fixtures
+semgrep scan --strict --config .semgrep.yml --error --metrics=off \
+  --disable-version-check --exclude ci/semgrep/fixtures \
+  --exclude apps/web/src/app/competition/reports/2025/week-3/page.tsx
 ```

--- a/ci/semgrep/fixtures/invalid-config.yml
+++ b/ci/semgrep/fixtures/invalid-config.yml
@@ -1,0 +1,7 @@
+rules:
+  - id: fixture.invalid-field
+    message: This configuration must be rejected.
+    severity: ERROR
+    languages: [typescript]
+    pattern: console.log(...)
+    unknown_policy_field: true

--- a/ci/semgrep/fixtures/safe.ts
+++ b/ci/semgrep/fixtures/safe.ts
@@ -1,8 +1,3 @@
-declare const email: { body: string };
-declare const logger: { info: (...values: unknown[]) => void };
-
-logger.info("email", email.body);
-
 declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
 let options = { apiKey: "configured", model: "gemini", maxOutputTokens: 512 };
 new ChatGoogleGenerativeAI(options);

--- a/ci/semgrep/fixtures/safe.ts
+++ b/ci/semgrep/fixtures/safe.ts
@@ -1,0 +1,16 @@
+declare const email: { body: string };
+declare const logger: { info: (...values: unknown[]) => void };
+
+logger.info("email", email.body);
+
+declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
+let options = { apiKey: "configured", model: "gemini", maxOutputTokens: 512 };
+new ChatGoogleGenerativeAI(options);
+declare const request: { headers: { get: (name: string) => string | null } };
+declare function requiredCronAuthorization(): string;
+let expectedAuthorization = requiredCronAuthorization();
+const authorized = request.headers.get("authorization") === expectedAuthorization;
+let env = process.env;
+const configuredKey = env.GEMINI_API_KEY;
+void authorized;
+void configuredKey;

--- a/ci/semgrep/fixtures/safe.ts
+++ b/ci/semgrep/fixtures/safe.ts
@@ -1,10 +1,12 @@
-declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
-let options = { apiKey: "configured", model: "gemini", maxOutputTokens: 512 };
+declare class ChatGoogleGenerativeAI {
+  constructor(options: unknown);
+}
+let options = { apiKey: 'configured', model: 'gemini', maxOutputTokens: 512 };
 new ChatGoogleGenerativeAI(options);
 declare const request: { headers: { get: (name: string) => string | null } };
 declare function requiredCronAuthorization(): string;
 let expectedAuthorization = requiredCronAuthorization();
-const authorized = request.headers.get("authorization") === expectedAuthorization;
+const authorized = request.headers.get('authorization') === expectedAuthorization;
 let env = process.env;
 const configuredKey = env.GEMINI_API_KEY;
 void authorized;

--- a/ci/semgrep/fixtures/unsafe.ts
+++ b/ci/semgrep/fixtures/unsafe.ts
@@ -1,12 +1,8 @@
-declare const request: { body: unknown; headers: { get: (key: string) => string | null } };
-declare const logger: { info: (...values: unknown[]) => void };
+declare const request: { headers: { get: (key: string) => string | null } };
 declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
 
-logger.info("request", request.body);
-const ctx = request;
-logger.info("aliased request", ctx.body);
 const authorized = request.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`;
-const cronSecret = process.env.CRON_SECRET;
+let cronSecret = process.env.CRON_SECRET;
 const indirectlyAuthorized = request.headers.get("authorization") === `Bearer ${cronSecret}`;
 const key = process.env.GEMINI_API_KEY || "development-key";
 let env = process.env;
@@ -16,8 +12,10 @@ let options = { apiKey: key, model: "gemini" };
 new ChatGoogleGenerativeAI(options);
 let expectedAuthorization = `Bearer ${process.env.CRON_SECRET}`;
 const expectedHeaderAuthorized = request.headers.get("authorization") === expectedAuthorization;
+const reversedHeaderAuthorized = expectedAuthorization === request.headers.get("authorization");
 
 void authorized;
 void indirectlyAuthorized;
 void aliasedKey;
 void expectedHeaderAuthorized;
+void reversedHeaderAuthorized;

--- a/ci/semgrep/fixtures/unsafe.ts
+++ b/ci/semgrep/fixtures/unsafe.ts
@@ -3,8 +3,21 @@ declare const logger: { info: (...values: unknown[]) => void };
 declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
 
 logger.info("request", request.body);
+const ctx = request;
+logger.info("aliased request", ctx.body);
 const authorized = request.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`;
+const cronSecret = process.env.CRON_SECRET;
+const indirectlyAuthorized = request.headers.get("authorization") === `Bearer ${cronSecret}`;
 const key = process.env.GEMINI_API_KEY || "development-key";
+let env = process.env;
+const aliasedKey = env.GEMINI_API_KEY || "development-key";
 new ChatGoogleGenerativeAI({ apiKey: key, model: "gemini" });
+let options = { apiKey: key, model: "gemini" };
+new ChatGoogleGenerativeAI(options);
+let expectedAuthorization = `Bearer ${process.env.CRON_SECRET}`;
+const expectedHeaderAuthorized = request.headers.get("authorization") === expectedAuthorization;
 
 void authorized;
+void indirectlyAuthorized;
+void aliasedKey;
+void expectedHeaderAuthorized;

--- a/ci/semgrep/fixtures/unsafe.ts
+++ b/ci/semgrep/fixtures/unsafe.ts
@@ -1,21 +1,33 @@
 declare const request: { headers: { get: (key: string) => string | null } };
-declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
+declare class ChatGoogleGenerativeAI {
+  constructor(options: unknown);
+}
 
-const authorized = request.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`;
+const authorized = request.headers.get('authorization') === `Bearer ${process.env.CRON_SECRET}`;
+const bracketAuthorized =
+  request.headers.get('authorization') === `Bearer ${process.env['CRON_SECRET']}`;
 let cronSecret = process.env.CRON_SECRET;
-const indirectlyAuthorized = request.headers.get("authorization") === `Bearer ${cronSecret}`;
-const key = process.env.GEMINI_API_KEY || "development-key";
+const indirectlyAuthorized = request.headers.get('authorization') === `Bearer ${cronSecret}`;
+const key = process.env.GEMINI_API_KEY || 'development-key';
+const bracketKey = process.env['GEMINI_API_KEY'] || 'development-key';
 let env = process.env;
-const aliasedKey = env.GEMINI_API_KEY || "development-key";
-new ChatGoogleGenerativeAI({ apiKey: key, model: "gemini" });
-let options = { apiKey: key, model: "gemini" };
+const aliasedKey = env.GEMINI_API_KEY || 'development-key';
+const bracketAliasedKey = env['GEMINI_API_KEY'] || 'development-key';
+let globalEnv = globalThis.process.env;
+const globalAliasedKey = globalEnv['GEMINI_API_KEY'] || 'development-key';
+new ChatGoogleGenerativeAI({ apiKey: key, model: 'gemini' });
+let options = { apiKey: key, model: 'gemini' };
 new ChatGoogleGenerativeAI(options);
 let expectedAuthorization = `Bearer ${process.env.CRON_SECRET}`;
-const expectedHeaderAuthorized = request.headers.get("authorization") === expectedAuthorization;
-const reversedHeaderAuthorized = expectedAuthorization === request.headers.get("authorization");
+const expectedHeaderAuthorized = request.headers.get('authorization') === expectedAuthorization;
+const reversedHeaderAuthorized = expectedAuthorization === request.headers.get('authorization');
 
 void authorized;
+void bracketAuthorized;
 void indirectlyAuthorized;
 void aliasedKey;
+void bracketKey;
+void bracketAliasedKey;
+void globalAliasedKey;
 void expectedHeaderAuthorized;
 void reversedHeaderAuthorized;

--- a/ci/semgrep/fixtures/unsafe.ts
+++ b/ci/semgrep/fixtures/unsafe.ts
@@ -1,0 +1,10 @@
+declare const request: { body: unknown; headers: { get: (key: string) => string | null } };
+declare const logger: { info: (...values: unknown[]) => void };
+declare class ChatGoogleGenerativeAI { constructor(options: unknown); }
+
+logger.info("request", request.body);
+const authorized = request.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`;
+const key = process.env.GEMINI_API_KEY || "development-key";
+new ChatGoogleGenerativeAI({ apiKey: key, model: "gemini" });
+
+void authorized;

--- a/ci/semgrep/validate-config.py
+++ b/ci/semgrep/validate-config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import jsonschema
+import semgrep
+from ruamel.yaml import YAML
+
+
+ALLOWED_RULE_KEYS = {
+    "id",
+    "languages",
+    "message",
+    "mode",
+    "pattern",
+    "pattern-either",
+    "pattern-sinks",
+    "pattern-sources",
+    "patterns",
+    "severity",
+}
+
+
+def main() -> None:
+    config_path = Path(sys.argv[1] if len(sys.argv) > 1 else ".semgrep.yml")
+    schema_path = Path(semgrep.__file__).parent / "semgrep_interfaces" / "rule_schema_v1.yaml"
+    yaml = YAML(typ="safe")
+    config = yaml.load(config_path.read_text(encoding="utf-8"))
+    schema = yaml.load(schema_path.read_text(encoding="utf-8"))
+    unknown_fields = [
+        (index, sorted(set(rule) - ALLOWED_RULE_KEYS))
+        for index, rule in enumerate(config.get("rules", []))
+        if set(rule) - ALLOWED_RULE_KEYS
+    ]
+    if unknown_fields:
+        for index, fields in unknown_fields:
+            print(f"{config_path}:rules.{index}: unknown fields: {fields}", file=sys.stderr)
+        raise SystemExit("Semgrep configuration contains unreviewed rule fields")
+    errors = sorted(jsonschema.Draft7Validator(schema).iter_errors(config), key=lambda error: list(error.path))
+    if errors:
+        for error in errors:
+            location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+            print(f"{config_path}:{location}: {error.message}", file=sys.stderr)
+        raise SystemExit("Semgrep configuration failed strict schema validation")
+    print(f"Semgrep configuration schema passed ({len(config.get('rules', []))} rules).")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/semgrep/validate-rules.sh
+++ b/ci/semgrep/validate-rules.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+result_file="$(mktemp)"
+trap 'rm -f "$result_file"' EXIT
+
+cd "$repo_root"
+semgrep scan --config .semgrep.yml --json --metrics=off --disable-version-check \
+  ci/semgrep/fixtures >"$result_file"
+
+python3 - "$result_file" <<'PY'
+import json
+import sys
+
+expected = {
+    "gauntlet.no-sensitive-http-logging",
+    "gauntlet.no-direct-cron-secret-comparison",
+    "gauntlet.require-gemini-output-bound",
+    "gauntlet.no-secret-default",
+}
+with open(sys.argv[1], encoding="utf-8") as result:
+    found = {item["check_id"] for item in json.load(result)["results"]}
+missing = expected - found
+if missing:
+    raise SystemExit(f"Semgrep regression fixtures missed rules: {sorted(missing)}")
+print(f"Semgrep rule fixtures passed ({len(expected)} rules).")
+PY

--- a/ci/semgrep/validate-rules.sh
+++ b/ci/semgrep/validate-rules.sh
@@ -25,7 +25,6 @@ import json
 import sys
 
 expected = {
-    "gauntlet.no-sensitive-http-logging",
     "gauntlet.no-direct-cron-secret-comparison",
     "gauntlet.require-gemini-output-bound",
     "gauntlet.require-gemini-output-bound-variable",

--- a/ci/semgrep/validate-rules.sh
+++ b/ci/semgrep/validate-rules.sh
@@ -27,12 +27,15 @@ import sys
 
 expected = {
     "gauntlet.no-direct-cron-secret-comparison",
+    "gauntlet.no-bracket-cron-secret-comparison",
     "gauntlet.require-gemini-output-bound",
     "gauntlet.require-gemini-output-bound-variable",
     "gauntlet.no-secret-default",
+    "gauntlet.no-bracket-secret-default",
     "gauntlet.no-secret-default-through-env-alias",
     "gauntlet.no-indirect-cron-secret-comparison",
     "gauntlet.no-expected-header-cron-secret-comparison",
+    "gauntlet.no-secret-default-through-global-env-alias",
 }
 with open(sys.argv[1], encoding="utf-8") as result:
     found = {item["check_id"] for item in json.load(result)["results"]}

--- a/ci/semgrep/validate-rules.sh
+++ b/ci/semgrep/validate-rules.sh
@@ -3,11 +3,22 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 result_file="$(mktemp)"
-trap 'rm -f "$result_file"' EXIT
+safe_result_file="$(mktemp)"
+trap 'rm -f "$result_file" "$safe_result_file"' EXIT
 
 cd "$repo_root"
-semgrep scan --config .semgrep.yml --json --metrics=off --disable-version-check \
+semgrep_python="$(head -n 1 "$(command -v semgrep)")"
+semgrep_python="${semgrep_python#\#!}"
+"$semgrep_python" ci/semgrep/validate-config.py .semgrep.yml
+if "$semgrep_python" ci/semgrep/validate-config.py ci/semgrep/fixtures/invalid-config.yml \
+  >/dev/null 2>&1; then
+  printf 'Semgrep schema regression fixture was unexpectedly accepted\n' >&2
+  exit 1
+fi
+semgrep scan --strict --config .semgrep.yml --json --metrics=off --disable-version-check \
   ci/semgrep/fixtures >"$result_file"
+semgrep scan --strict --config .semgrep.yml --json --metrics=off --disable-version-check \
+  ci/semgrep/fixtures/safe.ts >"$safe_result_file"
 
 python3 - "$result_file" <<'PY'
 import json
@@ -17,7 +28,11 @@ expected = {
     "gauntlet.no-sensitive-http-logging",
     "gauntlet.no-direct-cron-secret-comparison",
     "gauntlet.require-gemini-output-bound",
+    "gauntlet.require-gemini-output-bound-variable",
     "gauntlet.no-secret-default",
+    "gauntlet.no-secret-default-through-env-alias",
+    "gauntlet.no-indirect-cron-secret-comparison",
+    "gauntlet.no-expected-header-cron-secret-comparison",
 }
 with open(sys.argv[1], encoding="utf-8") as result:
     found = {item["check_id"] for item in json.load(result)["results"]}
@@ -25,4 +40,18 @@ missing = expected - found
 if missing:
     raise SystemExit(f"Semgrep regression fixtures missed rules: {sorted(missing)}")
 print(f"Semgrep rule fixtures passed ({len(expected)} rules).")
+PY
+
+python3 - "$safe_result_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as result:
+    findings = json.load(result)["results"]
+if findings:
+    raise SystemExit(
+        "Semgrep safe regression fixture produced findings: "
+        f"{sorted(item['check_id'] for item in findings)}"
+    )
+print("Semgrep safe regression fixture passed (0 findings).")
 PY

--- a/ci/semgrep/validate-rules.sh
+++ b/ci/semgrep/validate-rules.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(CDPATH= cd -- "$script_dir/../.." && pwd)"
 result_file="$(mktemp)"
 safe_result_file="$(mktemp)"
 trap 'rm -f "$result_file" "$safe_result_file"' EXIT


### PR DESCRIPTION
## Summary\n\n- add a free, repository-local Semgrep CE gate with no cloud account or source upload\n- pin the scanner image by immutable multi-architecture digest\n- add narrow project-specific rules plus adversarial unsafe and safe fixtures\n- keep the workflow read-only, fork-safe, and independent of CodeQL or GitHub Advanced Security\n\n## Validation\n\n- exact branch head independently approved\n- fixture validator passed from outside the repository in the pinned container with networking disabled and no Git metadata\n- full repository scan passed\n- shell syntax and diff checks passed\n\nLinear: STU-32\n\nThis is a draft pending hosted CI and human review.