### PR TITLE
Track Year Two buy-in status

### DIFF
--- a/apps/web/prisma/migrations/20260809150000_add_buy_in_status/migration.sql
+++ b/apps/web/prisma/migrations/20260809150000_add_buy_in_status/migration.sql
@@ -1,0 +1,43 @@
+-- Track buy-in collection for both returning teams and waitlist registrations.
+ALTER TABLE "ReturnConfirmation"
+ADD COLUMN IF NOT EXISTS "buyInStatus" TEXT NOT NULL DEFAULT 'UNPAID'
+CHECK ("buyInStatus" IN ('UNPAID', 'PAID', 'PARTIAL', 'EXEMPT'));
+
+ALTER TABLE "WaitlistEntry"
+ADD COLUMN IF NOT EXISTS "buyInStatus" TEXT NOT NULL DEFAULT 'UNPAID'
+CHECK ("buyInStatus" IN ('UNPAID', 'PAID', 'PARTIAL', 'EXEMPT'));
+
+-- Name-only admin registrations use the existing placeholder-email convention.
+INSERT INTO "WaitlistEntry" ("id", "email", "name", "notes", "buyInStatus", "createdAt")
+VALUES
+    ('admin_waitlist_lineeth_friend_20260809', 'lineeth.friend@gauntlet.invalid', 'Lineeth + friend', 'Added by admin request on 2026-08-09.', 'UNPAID', CURRENT_TIMESTAMP),
+    ('admin_waitlist_sahil_modi_20260809', 'sahil.modi@gauntlet.invalid', 'Sahil Modi', 'Added by admin request on 2026-08-09.', 'PAID', CURRENT_TIMESTAMP + INTERVAL '1 millisecond')
+ON CONFLICT ("email") DO UPDATE
+SET "name" = EXCLUDED."name",
+    "buyInStatus" = EXCLUDED."buyInStatus";
+
+UPDATE "WaitlistEntry"
+SET "buyInStatus" = CASE
+    WHEN LOWER("name") IN ('brenden clerget', 'sean chokshi', 'ashwin dandapani', 'sahil modi') THEN 'PAID'
+    WHEN LOWER("name") = 'dhruv modi' THEN 'PARTIAL'
+    ELSE "buyInStatus"
+END
+WHERE LOWER("name") IN (
+    'brenden clerget',
+    'sean chokshi',
+    'ashwin dandapani',
+    'sahil modi',
+    'dhruv modi'
+);
+
+UPDATE "ReturnConfirmation"
+SET "buyInStatus" = CASE
+    WHEN "email" = 'dmethi@gmail.com' THEN 'EXEMPT'
+    ELSE 'PAID'
+END
+WHERE "id" IN (
+    'cmpqcv9br0000bbogze2fo1t0',
+    'cmrkv7lfw0002u97a18610tu0',
+    'cmrkwmeao0004u97a1ssppoxp',
+    'cmpq853fd00008zbh4n6vutb9'
+);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -8,20 +8,22 @@ datasource db {
 }
 
 model ReturnConfirmation {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  name      String
-  team      String?
-  createdAt DateTime @default(now())
+  id          String   @id @default(cuid())
+  email       String   @unique
+  name        String
+  team        String?
+  buyInStatus String   @default("UNPAID")
+  createdAt   DateTime @default(now())
 }
 
 model WaitlistEntry {
-  id         String   @id @default(cuid())
-  email      String   @unique
-  name       String
-  referredBy String?
-  notes      String?
-  createdAt  DateTime @default(now())
+  id          String   @id @default(cuid())
+  email       String   @unique
+  name        String
+  referredBy  String?
+  notes       String?
+  buyInStatus String   @default("UNPAID")
+  createdAt   DateTime @default(now())
 }
 
 model Proposal {


### PR DESCRIPTION
## What changed

- adds constrained buy-in status tracking for waitlist and returning-team records
- adds Lineeth + friend and Sahil Modi to the waitlist
- records the supplied paid, partial, and exempt statuses
- keeps the migration idempotent for Neon and Prisma deployment

## Why

Year Two registration now fills all 36 league slots, and buy-in collection needs a durable source of truth across both new and returning teams.

## Impact

Division III is full, and payment collection can distinguish unpaid, paid, partial, and exempt entries.

## Validation

- Prisma schema formatting and validation passed
- Neon migration passed on an isolated temporary branch
- migration applied successfully to production Neon
- production SQL readback confirmed every requested registration and payment status
- production league-structure endpoint confirmed 12 Division III teams and zero open slots
- repository lint passed
- repository type-check remains blocked by existing workspace package/type-resolution failures unrelated to this two-file change