### PR TITLE
ci(vercel): restore automatic production deployments

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,9 +4,6 @@
   "installCommand": "cd ../.. && pnpm install",
   "framework": "nextjs",
   "outputDirectory": ".next",
-  "git": {
-    "deploymentEnabled": false
-  },
   "functions": {
     "src/app/api/**/route.{js,ts}": {
       "maxDuration": 30

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
     "tailwindcss": ">=3"
   },
   "devDependencies": {
+    "@gauntlet/tokens": "workspace:*",
     "@chromatic-com/storybook": "^4.1.0",
     "@storybook/addon-a11y": "^9.1.1",
     "@storybook/addon-docs": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,9 +427,6 @@ importers:
 
   packages/ui:
     dependencies:
-      '@gauntlet/tokens':
-        specifier: workspace:*
-        version: link:../tokens
       framer-motion:
         specifier: '>=11'
         version: 12.23.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -452,6 +449,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: ^4.1.0
         version: 4.1.0(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.9)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)))
+      '@gauntlet/tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@storybook/addon-a11y':
         specifier: ^9.1.1
         version: 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.9)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)))


### PR DESCRIPTION
## Summary
- remove the repository-wide Vercel Git deployment opt-out
- declare the UI package build-time dependency on `@gauntlet/tokens` so clean Vercel builds succeed

## Validation
- `pnpm turbo build --filter=@gauntlet/web`
- repository pre-commit format, lint, and type-check checks

This restores preview deployments on branch pushes and production deployments from `main`.